### PR TITLE
Implement `Default` for `FoldHasher`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![warn(missing_docs)]
 
-use core::hash::Hasher;
+use core::hash::{BuildHasher, Hasher};
 
 #[cfg(feature = "std")]
 mod convenience;
@@ -274,6 +274,13 @@ pub mod fast {
             }
         }
     }
+
+    impl Default for FoldHasher {
+        #[inline]
+        fn default() -> Self {
+            FixedState::default().build_hasher()
+        }
+    }
 }
 
 /// The foldhash implementation optimized for quality.
@@ -329,6 +336,13 @@ pub mod quality {
         #[inline(always)]
         fn finish(&self) -> u64 {
             folded_multiply(self.inner.finish(), ARBITRARY0)
+        }
+    }
+
+    impl Default for FoldHasher {
+        #[inline]
+        fn default() -> Self {
+            FixedState::default().build_hasher()
         }
     }
 }


### PR DESCRIPTION
Most other well-known `Hasher` implementations implement `Default`[^1] which allows them to be used with standard library types like [`std::hash::BuildHasherDefault`](https://doc.rust-lang.org/std/hash/struct.BuildHasherDefault.html) and avoids the need for a `BuildHasher` like `FixedState` for quick experimentation.

This is redundant with the functionality in `FixedState::build_hasher` so it just defers to it.

Love this crate! Hope I can make it a bit more convenient for others to use. 🙂

[^1]: [aHash](https://github.com/tkaitchuck/aHash/blob/7d5c661a74b12d5bc5448b0b83fdb429190db1a3/src/lib.rs#L221), [rustc-hash](https://github.com/rust-lang/rustc-hash/blob/eb049a8209f58003957c34477a2d8d2729f6b633/src/lib.rs#L89), [std::hash::DefaultHasher](https://doc.rust-lang.org/src/std/hash/random.rs.html#116-125)