### PR TITLE
Don't query the time in `cfg(miri)` too

### DIFF
--- a/src/seed.rs
+++ b/src/seed.rs
@@ -194,7 +194,7 @@ mod global {
         // current time and an address from the allocator.
         #[cfg(feature = "std")]
         {
-            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+            #[cfg(not(any(miri, all(target_family = "wasm", target_os = "unknown"))))]
             if let Ok(duration) = std::time::UNIX_EPOCH.elapsed() {
                 seed = mix(seed, duration.subsec_nanos() as u64);
                 seed = mix(seed, duration.as_secs());


### PR DESCRIPTION
From https://github.com/orlp/foldhash/pull/4#issuecomment-2394342996:

[miri](https://github.com/rust-lang/miri) doesn't allow querying the time by default:
```rust
error: unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled
   --> /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/time.rs:130:22
    |
130 |         cvt(unsafe { libc::clock_gettime(clock, t.as_mut_ptr()) }).unwrap();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `clock_gettime` with `REALTIME` clocks not available when isolation is enabled
    |
    = help: set `MIRIFLAGS=-Zmiri-disable-isolation` to disable isolation;
    = help: or set `MIRIFLAGS=-Zmiri-isolation-error=warn` to make Miri return an error code from isolated operations (if supported for that operation) and continue with a warning
```

I've verified that `cargo miri test` works after this change.