### PR TITLE
Fix trivial collisions when hashing structures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub mod fast {
                 let hi = (self.sponge >> 64) as u64;
                 self.accumulator = folded_multiply(lo ^ self.accumulator, hi ^ self.fold_seed);
                 self.sponge = x.into();
-                self.sponge_len = 0;
+                self.sponge_len = bits as u8;
             } else {
                 self.sponge |= x.into() << self.sponge_len;
                 self.sponge_len += bits as u8;


### PR DESCRIPTION
To reproduce:
```rust
use std::hash::BuildHasher;
use foldhash::fast::RandomState;
//use ahash::RandomState;
//use std::hash::RandomState;
#[derive(Hash)]
struct Point3 {
    x: u64,
    y: u64,
    z: u64
}
#[derive(Hash)]
struct Point4 {
    x: u64,
    y: u64,
    z: u64,
    w: u64
}
fn main() {
    let st = RandomState::default();
    println!("000: {:?}", st.hash_one(Point3 { x: 0, y: 0, z: 0}));
    println!("001: {:?}", st.hash_one(Point3 { x: 0, y: 0, z: 1}));
    println!("002: {:?}", st.hash_one(Point3 { x: 0, y: 0, z: 2}));
    println!("0000: {:?}", st.hash_one(Point4 { x: 0, y: 0, z: 0, w: 0}));
    println!("0010: {:?}", st.hash_one(Point4 { x: 0, y: 0, z: 1, w: 0}));
    println!("0001: {:?}", st.hash_one(Point4 { x: 0, y: 0, z: 0, w: 1}));
    println!("0011: {:?}", st.hash_one(Point4 { x: 0, y: 0, z: 1, w: 1}));
}
```
Example output (before fix):
```
000: 8683679690595636920
001: 8683679690595636920
002: 8683679690595636920
0000: 5859751005930861946
0010: 16699619282587451823
0001: 16699619282587451823
0011: 16699619282587451823
```
This is caused by `write_num` resetting `sponge_len` to 0 when it overflows, causing the next `finish` or `write_num` to mistakenly assume it's empty. The bug leads to trivial HashDoS for some structures.