### PR TITLE
Eliminate some unreachable panic machinery in debug builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ const fn folded_multiply(x: u64, y: u64) -> u64 {
     {
         // We compute the full u64 x u64 -> u128 product, this is a single mul
         // instruction on x86-64, one mul plus one mulhi on ARM64.
-        let full = (x as u128) * (y as u128);
+        let full = (x as u128).wrapping_mul(y as u128);
         let lo = full as u64;
         let hi = (full >> 64) as u64;
 
@@ -133,8 +133,8 @@ const fn folded_multiply(x: u64, y: u64) -> u64 {
         let hy = (y >> 32) as u32;
 
         // u32 x u32 -> u64 the low bits of one with the high bits of the other.
-        let afull = (lx as u64) * (hy as u64);
-        let bfull = (hx as u64) * (ly as u64);
+        let afull = (lx as u64).wrapping_mul(hy as u64);
+        let bfull = (hx as u64).wrapping_mul(ly as u64);
 
         // Combine, swapping low/high of one of them so the upper bits of the
         // product of one combine with the lower bits of the other.


### PR DESCRIPTION
In debug builds `folded_multiply` includes unnecessary branching and panic machinery, because rustc can not reason that a `u64 x u64 -> u128` multiply can never overflow.

If these multiplications are replaced with `u128::wrapping_mul`, the codegen becomes identical to optimized builds. ([godbolt](https://godbolt.org/z/EcvvxG51n))

In an ideal world I would prefer to use `u64::carrying_mul`, but until that stabilizes `wrapping_mul` is probably our best bet.