### PR TITLE
Use 128-bit Widening Multiply on More Platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,23 @@ const ARBITRARY9: u64 = 0xd1310ba698dfb5ac;
 
 #[inline(always)]
 const fn folded_multiply(x: u64, y: u64) -> u64 {
-    #[cfg(target_pointer_width = "64")]
+    // The following code path is only fast if 64-bit to 128-bit widening
+    // multiplication is supported by the architecture. Most 64-bit
+    // architectures except SPARC64 and Wasm64 support it. However, the target
+    // pointer width doesn't always indicate that we are dealing with a 64-bit
+    // architecture, as there are ABIs that reduce the pointer width, especially
+    // on AArch64 and x86-64. WebAssembly (regardless of pointer width) supports
+    // 64-bit to 128-bit widening multiplication with the `wide-arithmetic`
+    // proposal.
+    #[cfg(any(
+        all(
+            target_pointer_width = "64",
+            not(any(target_arch = "sparc64", target_arch = "wasm64")),
+        ),
+        target_arch = "aarch64",
+        target_arch = "x86_64",
+        all(target_family = "wasm", target_feature = "wide-arithmetic"),
+    ))]
     {
         // We compute the full u64 x u64 -> u128 product, this is a single mul
         // instruction on x86-64, one mul plus one mulhi on ARM64.
@@ -123,7 +139,15 @@ const fn folded_multiply(x: u64, y: u64) -> u64 {
         lo ^ hi
     }
 
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(not(any(
+        all(
+            target_pointer_width = "64",
+            not(any(target_arch = "sparc64", target_arch = "wasm64")),
+        ),
+        target_arch = "aarch64",
+        target_arch = "x86_64",
+        all(target_family = "wasm", target_feature = "wide-arithmetic"),
+    )))]
     {
         // u64 x u64 -> u128 product is prohibitively expensive on 32-bit.
         // Decompose into 32-bit parts.


### PR DESCRIPTION
The 128-bit widening multiplication was previously gated by simply checking the target pointer width. This works as a simple heuristic, but a better heuristic can be used:

1. Most 64-bit architectures except SPARC64 and Wasm64 support the 128-bit widening multiplication, so it shouldn't be used on those two architectures.
2. The target pointer width doesn't always indicate that we are dealing with a 64-bit architecture, as there are ABIs that reduce the pointer width, especially on AArch64 and x86-64.
3. WebAssembly (regardless of pointer width) supports 64-bit to 128-bit widening multiplication with the `wide-arithmetic` proposal.

The `wide-arithmetic` proposal is available since the LLVM 20 update and works perfectly for this use case as can be seen here:

https://rust.godbolt.org/z/9jY7fxqxK

Using `wasmtime explore`, we can see it compiles down to the ideal instructions on x86-64:

```nasm
mulx rax, rdx, r10
xor rax, rdx
```