### PR TITLE
Lower MSRV to 1.60.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["algorithms", "no-std"]
 description = "A fast, non-cryptographic, minimally DoS-resistant hashing algorithm."
 edition = "2021"
 exclude = ["benches", "tools", "assets"]
+rust-version = "1.60"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
With just a couple insignificant changes we can lower our MSRV to 1.60.

We can't go any lower because we do need `target_has_atomic`.