### PR TITLE
Make `FoldHasher::with_seed` `const`

### DIFF
--- a/src/fast.rs
+++ b/src/fast.rs
@@ -22,7 +22,7 @@ impl<'a> FoldHasher<'a> {
     /// Initializes this [`FoldHasher`] with the given per-hasher seed and
     /// [`SharedSeed`].
     #[inline]
-    pub fn with_seed(per_hasher_seed: u64, shared_seed: &'a SharedSeed) -> FoldHasher<'a> {
+    pub const fn with_seed(per_hasher_seed: u64, shared_seed: &'a SharedSeed) -> FoldHasher<'a> {
         FoldHasher {
             accumulator: per_hasher_seed,
             sponge: 0,

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -20,7 +20,7 @@ impl<'a> FoldHasher<'a> {
     /// Initializes this [`FoldHasher`] with the given per-hasher seed and
     /// [`SharedSeed`].
     #[inline(always)]
-    pub fn with_seed(per_hasher_seed: u64, shared_seed: &'a SharedSeed) -> FoldHasher<'a> {
+    pub const fn with_seed(per_hasher_seed: u64, shared_seed: &'a SharedSeed) -> FoldHasher<'a> {
         FoldHasher {
             inner: fast::FoldHasher::with_seed(per_hasher_seed, shared_seed),
         }


### PR DESCRIPTION
Does what it says on the tin. Useful if you want to make a `const` fixed-seeded hasher that could then be cloned and used. Already possible to have the same effect by just storing a const seed and making a new one when you want to, but it is slightly more convenient like this for some use cases and I don't see a downside.