### PR TITLE
Mark hash_bytes_medium as inline never

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,7 @@ const fn rotate_right(x: u64, r: u32) -> u64 {
 }
 
 /// Hashes strings >= 16 bytes, has unspecified behavior when bytes.len() < 16.
+#[inline(never)]
 fn hash_bytes_medium(bytes: &[u8], mut s0: u64, mut s1: u64, fold_seed: u64) -> u64 {
     // Process 32 bytes per iteration, 16 bytes from the start, 16 bytes from
     // the end. On the last iteration these two chunks can overlap, but that is


### PR DESCRIPTION
Reduce the inlining cost of `FoldHasher::write` by marking `hash_bytes_medium` as `#[inline(never)]`. This reduces the inlining cost of `Hash::hash(str)` and means the `write_length_prefix` and `finish` methods are more likely to be inlined and efficiently optimise by the compiler.

```
StrUuid/hashonly-struuid-foldhash-fast                                                                             
                        time:   [3.8693 ns 3.8759 ns 3.8845 ns]
                        change: [-30.347% -30.207% -30.075%] (p = 0.00 < 0.05)
                        Performance has improved.

StrDate/hashonly-strdate-foldhash-fast                                                                             
                        time:   [1.3790 ns 1.3990 ns 1.4221 ns]
                        change: [-74.467% -74.116% -73.656%] (p = 0.00 < 0.05)
                        Performance has improved.

StrEnglishWord/hashonly-strenglishword-foldhash-fast                                                                             
                        time:   [1.4834 ns 1.4860 ns 1.4887 ns]
                        change: [-73.295% -73.243% -73.190%] (p = 0.00 < 0.05)
                        Performance has improved.

StrUrl/hashonly-strurl-foldhash-fast                                                                             
                        time:   [6.2293 ns 6.2748 ns 6.3197 ns]
                        change: [-17.006% -16.186% -15.326%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Per discussion on #32 