### PR TITLE
Better string hash inlining/unrolling

### DIFF
--- a/src/fast.rs
+++ b/src/fast.rs
@@ -15,7 +15,7 @@ pub struct FoldHasher<'a> {
     accumulator: u64,
     sponge: u128,
     sponge_len: u8,
-    seeds: &'a [u64; 4],
+    seeds: &'a [u64; 6],
 }
 
 impl<'a> FoldHasher<'a> {
@@ -60,7 +60,10 @@ impl<'a> Hasher for FoldHasher<'a> {
         if len <= 16 {
             self.accumulator = hash_bytes_short(bytes, self.accumulator, self.seeds);
         } else {
-            self.accumulator = hash_bytes_long(bytes, self.accumulator, self.seeds);
+            unsafe {
+                // SAFETY: we checked that the length is > 16 bytes.
+                self.accumulator = hash_bytes_long(bytes, self.accumulator, self.seeds);
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,9 +248,8 @@ fn hash_bytes_short(bytes: &[u8], accumulator: u64, seeds: &[u64; 6]) -> u64 {
     folded_multiply(s0, s1)
 }
 
-
 /// Load 8 bytes into a u64 word at the given offset.
-/// 
+///
 /// # Safety
 /// You must ensure that offset + 8 <= bytes.len().
 #[inline(always)]
@@ -262,7 +261,7 @@ unsafe fn load(bytes: &[u8], offset: usize) -> u64 {
 }
 
 /// Hashes strings > 16 bytes.
-/// 
+///
 /// # Safety
 /// v.len() must be > 16 bytes.
 #[cold]
@@ -283,8 +282,8 @@ unsafe fn hash_bytes_long(mut v: &[u8], accumulator: u64, seeds: &[u64; 6]) -> u
             loop {
                 unsafe {
                     // SAFETY: we checked the length is > 256, we index at most v[..96].
-                    s0 = folded_multiply(load(v, 0) ^ s0,  load(v, 48) ^ seeds[0]);
-                    s1 = folded_multiply(load(v, 8) ^ s1,  load(v, 56) ^ seeds[0]);
+                    s0 = folded_multiply(load(v, 0) ^ s0, load(v, 48) ^ seeds[0]);
+                    s1 = folded_multiply(load(v, 8) ^ s1, load(v, 56) ^ seeds[0]);
                     s2 = folded_multiply(load(v, 16) ^ s2, load(v, 64) ^ seeds[0]);
                     s3 = folded_multiply(load(v, 24) ^ s3, load(v, 72) ^ seeds[0]);
                     s4 = folded_multiply(load(v, 32) ^ s4, load(v, 80) ^ seeds[0]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ const ARBITRARY6: u64 = 0xc0ac29b7c97c50dd;
 const ARBITRARY7: u64 = 0x3f84d5b5b5470917;
 const ARBITRARY8: u64 = 0x9216d5d98979fb1b;
 const ARBITRARY9: u64 = 0xd1310ba698dfb5ac;
+const ARBITRARY10: u64 = 0x2ffd72dbd01adfb7;
+const ARBITRARY11: u64 = 0xb8e1afed6a267e96;
 
 #[inline(always)]
 const fn folded_multiply(x: u64, y: u64) -> u64 {
@@ -220,9 +222,12 @@ const fn rotate_right(x: u64, r: u32) -> u64 {
     }
 }
 
-/// Hashes strings <= 16 bytes, has unspecified behavior when bytes.len() < 16.
+#[cold]
+fn cold_path() {}
+
+/// Hashes strings <= 16 bytes, has unspecified behavior when bytes.len() > 16.
 #[inline(always)]
-fn hash_bytes_short(bytes: &[u8], accumulator: u64, seeds: &[u64; 4]) -> u64 {
+fn hash_bytes_short(bytes: &[u8], accumulator: u64, seeds: &[u64; 6]) -> u64 {
     let len = bytes.len();
     let mut s0 = accumulator;
     let mut s1 = seeds[1];
@@ -243,61 +248,94 @@ fn hash_bytes_short(bytes: &[u8], accumulator: u64, seeds: &[u64; 4]) -> u64 {
     folded_multiply(s0, s1)
 }
 
-/// Hashes strings > 16 bytes, has unspecified behavior when bytes.len() <= 16.
+
+/// Load 8 bytes into a u64 word at the given offset.
+/// 
+/// # Safety
+/// You must ensure that offset + 8 <= bytes.len().
+#[inline(always)]
+unsafe fn load(bytes: &[u8], offset: usize) -> u64 {
+    // In most (but not all) cases this unsafe code is not necessary to avoid
+    // the bounds checks in the below code, but the register allocation became
+    // worse if I replaced those calls which could be replaced with safe code.
+    unsafe { bytes.as_ptr().add(offset).cast::<u64>().read_unaligned() }
+}
+
+/// Hashes strings > 16 bytes.
+/// 
+/// # Safety
+/// v.len() must be > 16 bytes.
 #[cold]
 #[inline(never)]
-fn hash_bytes_long(mut bytes: &[u8], accumulator: u64, seeds: &[u64; 4]) -> u64 {
+unsafe fn hash_bytes_long(mut v: &[u8], accumulator: u64, seeds: &[u64; 6]) -> u64 {
     let mut s0 = accumulator;
     let mut s1 = s0.wrapping_add(seeds[1]);
-    if bytes.len() >= 256 {
+
+    if v.len() > 128 {
+        cold_path();
         let mut s2 = s0.wrapping_add(seeds[2]);
         let mut s3 = s0.wrapping_add(seeds[3]);
-        let chunks = bytes.chunks_exact(64);
-        let remainder = chunks.remainder().len();
-        for chunk in chunks {
-            let a = u64::from_ne_bytes(chunk[0..8].try_into().unwrap());
-            let b = u64::from_ne_bytes(chunk[8..16].try_into().unwrap());
-            let c = u64::from_ne_bytes(chunk[16..24].try_into().unwrap());
-            let d = u64::from_ne_bytes(chunk[24..32].try_into().unwrap());
-            let e = u64::from_ne_bytes(chunk[32..40].try_into().unwrap());
-            let f = u64::from_ne_bytes(chunk[40..48].try_into().unwrap());
-            let g = u64::from_ne_bytes(chunk[48..56].try_into().unwrap());
-            let h = u64::from_ne_bytes(chunk[56..64].try_into().unwrap());
-            s0 = folded_multiply(a ^ s0, e ^ seeds[0]);
-            s1 = folded_multiply(b ^ s1, f ^ seeds[0]);
-            s2 = folded_multiply(c ^ s2, g ^ seeds[0]);
-            s3 = folded_multiply(d ^ s3, h ^ seeds[0]);
+
+        if v.len() > 256 {
+            cold_path();
+            let mut s4 = s0.wrapping_add(seeds[4]);
+            let mut s5 = s0.wrapping_add(seeds[5]);
+            loop {
+                unsafe {
+                    // SAFETY: we checked the length is > 256, we index at most v[..96].
+                    s0 = folded_multiply(load(v, 0) ^ s0,  load(v, 48) ^ seeds[0]);
+                    s1 = folded_multiply(load(v, 8) ^ s1,  load(v, 56) ^ seeds[0]);
+                    s2 = folded_multiply(load(v, 16) ^ s2, load(v, 64) ^ seeds[0]);
+                    s3 = folded_multiply(load(v, 24) ^ s3, load(v, 72) ^ seeds[0]);
+                    s4 = folded_multiply(load(v, 32) ^ s4, load(v, 80) ^ seeds[0]);
+                    s5 = folded_multiply(load(v, 40) ^ s5, load(v, 88) ^ seeds[0]);
+                }
+                v = &v[96..];
+                if v.len() <= 256 {
+                    break;
+                }
+            }
+            s0 ^= s4;
+            s1 ^= s5;
+        }
+
+        loop {
+            unsafe {
+                // SAFETY: we checked the length is > 128, we index at most v[..64].
+                s0 = folded_multiply(load(v, 0) ^ s0, load(v, 32) ^ seeds[0]);
+                s1 = folded_multiply(load(v, 8) ^ s1, load(v, 40) ^ seeds[0]);
+                s2 = folded_multiply(load(v, 16) ^ s2, load(v, 48) ^ seeds[0]);
+                s3 = folded_multiply(load(v, 24) ^ s3, load(v, 56) ^ seeds[0]);
+            }
+            v = &v[64..];
+            if v.len() <= 128 {
+                break;
+            }
         }
         s0 ^= s2;
         s1 ^= s3;
-
-        if remainder > 0 {
-            bytes = &bytes[bytes.len() - remainder.max(16)..];
-        } else {
-            return s0 ^ s1;
-        }
     }
 
-    // Process 32 bytes per iteration, 16 bytes from the start, 16 bytes from
-    // the end. On the last iteration these two chunks can overlap, but that is
-    // perfectly fine.
-    let left_to_right = bytes.chunks_exact(16);
-    let mut right_to_left = bytes.rchunks_exact(16);
-    for lo in left_to_right {
-        let hi = right_to_left.next().unwrap();
-        let unconsumed_start = lo.as_ptr();
-        let unconsumed_end = hi.as_ptr_range().end;
-        if unconsumed_start >= unconsumed_end {
-            break;
+    let len = v.len();
+    unsafe {
+        // SAFETY: our precondition ensures our length is at least 16, and the
+        // above loops do not reduce the length under that. This protects our
+        // first iteration of this loop, the further iterations are protected
+        // directly by the checks on len.
+        s0 = folded_multiply(load(v, 0) ^ s0, load(v, len - 16) ^ seeds[0]);
+        s1 = folded_multiply(load(v, 8) ^ s1, load(v, len - 8) ^ seeds[0]);
+        if len >= 32 {
+            s0 = folded_multiply(load(v, 16) ^ s0, load(v, len - 32) ^ seeds[0]);
+            s1 = folded_multiply(load(v, 24) ^ s1, load(v, len - 24) ^ seeds[0]);
+            if len >= 64 {
+                s0 = folded_multiply(load(v, 32) ^ s0, load(v, len - 48) ^ seeds[0]);
+                s1 = folded_multiply(load(v, 40) ^ s1, load(v, len - 40) ^ seeds[0]);
+                if len >= 96 {
+                    s0 = folded_multiply(load(v, 48) ^ s0, load(v, len - 64) ^ seeds[0]);
+                    s1 = folded_multiply(load(v, 56) ^ s1, load(v, len - 56) ^ seeds[0]);
+                }
+            }
         }
-
-        let a = u64::from_ne_bytes(lo[0..8].try_into().unwrap());
-        let b = u64::from_ne_bytes(lo[8..16].try_into().unwrap());
-        let c = u64::from_ne_bytes(hi[0..8].try_into().unwrap());
-        let d = u64::from_ne_bytes(hi[8..16].try_into().unwrap());
-        s0 = folded_multiply(a ^ s0, c ^ seeds[0]);
-        s1 = folded_multiply(b ^ s1, d ^ seeds[0]);
     }
-
     s0 ^ s1
 }

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -4,7 +4,7 @@ use core::hash::{BuildHasher, Hasher};
 
 use crate::seed::SharedSeed;
 
-use crate::{fast, folded_multiply, ARBITRARY0, ARBITRARY8};
+use crate::{fast, folded_multiply, ARBITRARY0, ARBITRARY4};
 
 /// A [`Hasher`] instance implementing foldhash, optimized for quality.
 ///
@@ -122,7 +122,7 @@ impl SeedableRandomState {
             // the quality hash to ensure better independence between seed
             // and hash.
             inner: fast::SeedableRandomState::with_seed(
-                folded_multiply(per_hasher_seed, ARBITRARY8),
+                folded_multiply(per_hasher_seed, ARBITRARY4),
                 shared_seed,
             ),
         }
@@ -157,7 +157,7 @@ impl FixedState {
             // the quality hash to ensure better independence between seed
             // and hash. If the seed is zero the folded multiply is zero,
             // preserving with_seed(0) == default().
-            inner: fast::FixedState::with_seed(folded_multiply(per_hasher_seed, ARBITRARY8)),
+            inner: fast::FixedState::with_seed(folded_multiply(per_hasher_seed, ARBITRARY4)),
         }
     }
 }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,12 +1,22 @@
 // These constants may end up unused depending on platform support.
 #[allow(unused)]
-use crate::{ARBITRARY1, ARBITRARY9};
+use crate::{ARBITRARY1, ARBITRARY5};
 
-use super::{folded_multiply, ARBITRARY2, ARBITRARY4, ARBITRARY5, ARBITRARY6, ARBITRARY7};
+use super::{
+    folded_multiply, ARBITRARY10, ARBITRARY11, ARBITRARY2, ARBITRARY6,
+    ARBITRARY7, ARBITRARY8, ARBITRARY9,
+};
 
 /// Used for FixedState, and RandomState if atomics for dynamic init are unavailable.
 const FIXED_GLOBAL_SEED: SharedSeed = SharedSeed {
-    seeds: [ARBITRARY4, ARBITRARY5, ARBITRARY6, ARBITRARY7],
+    seeds: [
+        ARBITRARY6,
+        ARBITRARY7,
+        ARBITRARY8,
+        ARBITRARY9,
+        ARBITRARY10,
+        ARBITRARY11,
+    ],
 };
 
 pub(crate) fn gen_per_hasher_seed() -> u64 {
@@ -66,7 +76,7 @@ pub(crate) fn gen_per_hasher_seed() -> u64 {
 /// and [`SeedableRandomState::with_seed`](crate::fast::SeedableRandomState::with_seed).
 #[derive(Clone, Debug)]
 pub struct SharedSeed {
-    pub(crate) seeds: [u64; 4],
+    pub(crate) seeds: [u64; 6],
 }
 
 impl SharedSeed {
@@ -92,7 +102,7 @@ impl SharedSeed {
     pub const fn from_u64(seed: u64) -> Self {
         macro_rules! mix {
             ($x: expr) => {
-                folded_multiply($x, ARBITRARY9)
+                folded_multiply($x, ARBITRARY5)
             };
         }
 
@@ -100,6 +110,8 @@ impl SharedSeed {
         let seed_b = mix!(mix!(mix!(seed_a)));
         let seed_c = mix!(mix!(mix!(seed_b)));
         let seed_d = mix!(mix!(mix!(seed_c)));
+        let seed_e = mix!(mix!(mix!(seed_d)));
+        let seed_f = mix!(mix!(mix!(seed_e)));
 
         // Zeroes form a weak-point for the multiply-mix, and zeroes tend to be
         // a common input. So we want our global seeds that are XOR'ed with the
@@ -112,6 +124,8 @@ impl SharedSeed {
                 seed_b | FORCED_ONES,
                 seed_c | FORCED_ONES,
                 seed_d | FORCED_ONES,
+                seed_e | FORCED_ONES,
+                seed_f | FORCED_ONES,
             ],
         }
     }
@@ -124,7 +138,7 @@ mod global {
     use core::sync::atomic::{AtomicU8, Ordering};
 
     fn generate_global_seed() -> SharedSeed {
-        let mix = |seed: u64, x: u64| folded_multiply(seed ^ x, ARBITRARY9);
+        let mix = |seed: u64, x: u64| folded_multiply(seed ^ x, ARBITRARY5);
 
         // Use address space layout randomization as our main randomness source.
         // This isn't great, but we don't advertise HashDoS resistance in the first
@@ -180,7 +194,7 @@ mod global {
 
     static GLOBAL_SEED_STORAGE: GlobalSeedStorage = GlobalSeedStorage {
         state: AtomicU8::new(UNINIT),
-        seed: UnsafeCell::new(SharedSeed { seeds: [0; 4] }),
+        seed: UnsafeCell::new(SharedSeed { seeds: [0; 6] }),
     };
 
     /// An object representing an initialized global seed.

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -3,8 +3,8 @@
 use crate::{ARBITRARY1, ARBITRARY5};
 
 use super::{
-    folded_multiply, ARBITRARY10, ARBITRARY11, ARBITRARY2, ARBITRARY6,
-    ARBITRARY7, ARBITRARY8, ARBITRARY9,
+    folded_multiply, ARBITRARY10, ARBITRARY11, ARBITRARY2, ARBITRARY6, ARBITRARY7, ARBITRARY8,
+    ARBITRARY9,
 };
 
 /// Used for FixedState, and RandomState if atomics for dynamic init are unavailable.


### PR DESCRIPTION
The string hash algorithm is mostly the same, although I added some new optimizations:

- increased the path for inputs > 256 bytes to a 6-times unrolled loop,
- added a path for inputs > 128 bytes with the old 4-times unrolled loop,
- fully unrolled the <= 128 byte input loop,
- use unsafe code for indexing to ensure no bounds checks and optimal codegen.

Especially the last two were important for small inputs.