### PR TITLE
Add nightly feature for slightly faster string hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.60"
 [features]
 default = ["std"]
 std = []
+nightly = []
 
 [dependencies]
 

--- a/src/fast.rs
+++ b/src/fast.rs
@@ -103,6 +103,13 @@ impl<'a> Hasher for FoldHasher<'a> {
         self.write_num(i as u64);
     }
 
+    #[cfg(feature = "nightly")]
+    #[inline(always)]
+    fn write_str(&mut self, s: &str) {
+        // Our write function already handles length differences.
+        self.write(s.as_bytes())
+    }
+
     #[inline(always)]
     fn finish(&self) -> u64 {
         if self.sponge_len > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,18 @@
 //!    [`RandomState`](fast::RandomState) by default but can be seeded in any manner.
 //!    This state must include an explicit reference to a [`SharedSeed`], and thus
 //!    this struct is 16 bytes as opposed to just 8 bytes for the previous two.
+//!
+//! ## Features
+//!
+//! This crate has the following features:
+//! - `nightly`, this feature improves string hashing performance
+//! slightly using the nightly-only Rust feature
+//! [`hasher_prefixfree_extras`](https://github.com/rust-lang/rust/issues/96762),
+//! - `std`, this enabled-by-default feature offers convenient aliases for `std`
+//! containers, but can be turned off for `#![no_std]` crates.
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
 #![warn(missing_docs)]
 
 pub mod fast;

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -63,6 +63,12 @@ impl<'a> Hasher for FoldHasher<'a> {
         self.inner.write_usize(i);
     }
 
+    #[cfg(feature = "nightly")]
+    #[inline(always)]
+    fn write_str(&mut self, s: &str) {
+        self.inner.write_str(s);
+    }
+
     #[inline(always)]
     fn finish(&self) -> u64 {
         folded_multiply(self.inner.finish(), ARBITRARY0)


### PR DESCRIPTION
This uses the nightly-only [`hasher_prefixfree_extras`](https://github.com/rust-lang/rust/issues/96762) API to save a bit of extra work when hashing `str`s.