### PR TITLE
Explicitly handle platforms with partial/no atomic support.

### DIFF
--- a/src/seed.rs
+++ b/src/seed.rs
@@ -56,7 +56,10 @@ pub(crate) fn gen_per_hasher_seed() -> u64 {
     // problematic contention.
     //
     // We use usize instead of 64-bit atomics for best platform support.
-    #[cfg(not(feature = "std"))]
+    //
+    // If the target has no atomic support, then the seed will have no further
+    // nondeterminism added.
+    #[cfg(all(not(feature = "std"), target_has_atomic = "ptr"))]
     {
         use core::sync::atomic::{AtomicUsize, Ordering};
         static PER_HASHER_NONDETERMINISM: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
Targets without atomic pointer support currently fail to compile (e.g., `thumbv4t-none-eabi`). This PR allows those targets to compile by more explicitly choosing an atomic type for `PER_HASHER_NONDETERMINISM`. If no atomic support is present, allow the result from `gen_per_hasher_seed` to have degraded nondeterminism.